### PR TITLE
fix: incorrect import statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ utilities provided by `@better-auth/utils`:
 Digest provides a way to hash an input using sha family hash functions. It wraps over `crypto.digest` and provide utilities to encode output in hex or base 64.
 
 ```ts
-import { createHash } from "@better-auth/utils/digest"
+import { createHash } from "@better-auth/utils/hash"
 
 const hashBuffer = await createHash("SHA-256").digest("text");
 const hashInHex = await createHash("SHA-256", "hex").digest("text");


### PR DESCRIPTION
Update README.md to correct the import statement for `createHash`.

* Replace the incorrect import statement `import { createHash } from "@better-auth/utils/digest"` with `import { createHash } from "@better-auth/utils/hash"`. 

