### PR TITLE
fix: remove typescript from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
 		"url": "https://github.com/better-auth/utils"
 	},
 	"dependencies": {
-		"typescript": "^5.8.2",
 		"uncrypto": "^0.1.3"
 	},
 	"devDependencies": {
@@ -32,6 +31,7 @@
 		"@types/node": "^22.10.1",
 		"bumpp": "^9.9.0",
 		"happy-dom": "^15.11.7",
+		"typescript": "^5.8.2",
 		"unbuild": "^2.0.0",
 		"vitest": "^2.1.8"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      typescript:
-        specifier: ^5.8.2
-        version: 5.8.2
       uncrypto:
         specifier: ^0.1.3
         version: 0.1.3
@@ -27,6 +24,9 @@ importers:
       happy-dom:
         specifier: ^15.11.7
         version: 15.11.7
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.8.2)


### PR DESCRIPTION
`typescript` should be in `devDependencies`. the package distributes `.mjs`/`.cjs` files so doesn't require typescript in any way. typescript weighs over 20mb: https://pkg-size.dev/typescript