### PR TITLE
Add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 		"type": "git",
 		"url": "git+https://github.com/better-auth/utils.git"
 	},
+	"homepage": "https://github.com/better-auth/utils#readme",
+	"bugs": {
+		"url": "https://github.com/better-auth/utils/issues"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@types/node": "^22.10.1",


### PR DESCRIPTION
## Summary
- add homepage metadata for the npm package README
- add ugs.url metadata pointing to the GitHub issue tracker

## Validation
- Parsed package.json with Node and verified homepage, ugs, and existing epository metadata.

Related: charles-openclaw/charles-microbounties#1317