### PR TITLE
chore: add package metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 		"type": "git",
 		"url": "git+https://github.com/better-auth/utils.git"
 	},
+	"homepage": "https://github.com/better-auth/utils#readme",
+	"bugs": {
+		"url": "https://github.com/better-auth/utils/issues"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@types/node": "^22.10.1",


### PR DESCRIPTION
## Summary

- add the package README as the npm `homepage`
- add the public GitHub issue tracker as `bugs.url`
- keep runtime code and dependencies unchanged

These fields make the links visible on npm and available to package tooling.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run` (10 files, 87 tests passed)
- `pnpm build`
- `npm pack --dry-run --json`

Related bounty report: https://github.com/charles-openclaw/charles-microbounties/issues/1317