### PR TITLE
fix(binary): bind TextEncoder when encoding

### DIFF
--- a/src/binary.test.ts
+++ b/src/binary.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { binary } from "./binary";
+
+describe("binary", () => {
+	it("encodes a string", () => {
+		expect(binary.encode("hi")).toEqual(new Uint8Array([104, 105]));
+	});
+
+	it("round-trips a string", () => {
+		const input = "Hello World!";
+
+		expect(binary.decode(binary.encode(input))).toBe(input);
+	});
+});

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,3 +1,5 @@
+import type { Uint8Array_ } from "./type";
+
 type Encoding = "utf-8" | "utf-16" | "iso-8859-1";
 
 type BinaryData = ArrayBuffer | ArrayBufferView;
@@ -13,5 +15,5 @@ export const binary = {
 		const decoder = decoders.get(encoding)!;
 		return decoder.decode(data);
 	},
-	encode: encoder.encode,
+	encode: (input?: string): Uint8Array_ => encoder.encode(input),
 };


### PR DESCRIPTION
- Fix `binary.encode()` throwing due to an unbound `TextEncoder.encode` method
- Preserve the portable `Uint8Array_` return type